### PR TITLE
GUI dev

### DIFF
--- a/GUIs/gui_dev/main.py
+++ b/GUIs/gui_dev/main.py
@@ -24,7 +24,7 @@ class MainWindow(QMainWindow):
 
 		#----------- External data ---------------------------------
 		# save a fits copy in the main window
-		self.fitsobj = FitsObj([],[],[])
+		self.fitsobj = FitsObj([],None,None)
 		self.linelist = []
 		self.newlinelist = []
 		self.z_est = [] #pd.DataFrame(columns=['Name', 'RA', 'DEC', 'Z', 'Z_err', 'Confidence', 'Flag'])

--- a/GUIs/gui_dev/menu_toolbars.py
+++ b/GUIs/gui_dev/menu_toolbars.py
@@ -234,29 +234,43 @@ class Custom_ToolBar(QToolBar):
 			filename = self.filenames[i-1]
 			self.filename = filename
 			self.fitsobj = loadspec._load_spec()
-			if len(self.fitsobj.flux.shape) > 1:
-				# new plot 2d
+			if (self.fitsobj.flux2d is not None) & (self.fitsobj.flux is None):
+				# only 2d spec exists
 				self.mW.sc.plot_spec2d(self.fitsobj.wave,
-									self.fitsobj.flux,
-									self.fitsobj.error,
+									self.fitsobj.flux2d,
+									self.fitsobj.error2d,
 									filename)
 				self._add_scale2d()
-			else:
+			elif (self.fitsobj.flux is not None) & (self.fitsobj.flux2d is None):
+				# only 1d spec exists
 				self.mW.sc.plot_spec(self.fitsobj.wave, 
 								self.fitsobj.flux, 
 								self.fitsobj.error,
 								filename)
 				self.s_combobox.clear()
+
+			elif (self.fitsobj.flux is not None) & (self.fitsobj.flux2d is not None):
+				# both 1d and 2d specs exist
+				self.mW.sc.plot_spec2d(self.fitsobj.wave,
+									self.fitsobj.flux2d,
+									self.fitsobj.error2d,
+									filename)
+				self.mW.sc.replot2d(self.fitsobj.wave, 
+								self.fitsobj.flux, 
+								self.fitsobj.error)
+				self._add_scale2d()
+
 			
 			self.send_filename.emit(filename)
 			self.send_fitsobj.emit(self.fitsobj)		
 
 	def _add_scale2d(self):
-		self.s_combobox.setMaxVisibleItems(4)
+		self.s_combobox.setMaxCount(4)
 		self.s_combobox.addItems(['Linear', 'Log', 'Sqrt', 'Square'])
 		self.s_combobox.setCurrentIndex(0)
 		self.s_combobox.currentIndexChanged.connect(self._scaling_changed)
 
+		self.n_combobox.setMaxCount(12)
 		self.n_combobox.addItems(['None','MinMax', '99.5%', '99%', '98%', '97%', '96%', '95%', '92.5%', '90%', 'Z-Score', 'Manual'])
 		self.n_combobox.setCurrentIndex(0)
 		self.n_combobox.currentIndexChanged.connect(self._normalization_changed)
@@ -265,21 +279,21 @@ class Custom_ToolBar(QToolBar):
 		self.max_range.setReadOnly(False)
 
 	def _scaling_changed(self, i):
-		if len(self.fitsobj.flux.shape) > 1:
+		if self.fitsobj.flux2d is not None:
 			self.mW.sc.plot_spec2d(self.fitsobj.wave,
-								self.fitsobj.flux,
-								self.fitsobj.error,
+								self.fitsobj.flux2d,
+								self.fitsobj.error2d,
 								self.filename, scale=i)
 			self.scale = i
 		else:
 			pass
 
 	def _normalization_changed(self, i):
-		if len(self.fitsobj.flux.shape) > 1:
+		if self.fitsobj.flux2d is not None:
 			if i < 11:
 				self.mW.sc.plot_spec2d(self.fitsobj.wave,
-									self.fitsobj.flux,
-									self.fitsobj.error,
+									self.fitsobj.flux2d,
+									self.fitsobj.error2d,
 									self.filename, 
 									scale=self.scale,
 									normalization=i)
@@ -294,8 +308,8 @@ class Custom_ToolBar(QToolBar):
 		manual_range = [float(self.min_range.text()), float(self.max_range.text())]
 		self.n_combobox.setCurrentIndex(11)
 		self.mW.sc.plot_spec2d(self.fitsobj.wave,
-							self.fitsobj.flux,
-							self.fitsobj.error,
+							self.fitsobj.flux2d,
+							self.fitsobj.error2d,
 							self.filename,
 							scale=self.scale,
 							normalization=manual_range)

--- a/GUIs/gui_dev/spec_plot.py
+++ b/GUIs/gui_dev/spec_plot.py
@@ -66,11 +66,11 @@ class MplCanvas(FigureCanvasQTAgg):
 		self.fig.clf()
 		self.axes = self.fig.add_subplot(111)
 		self.axes.cla()
-		self.axes.plot(wave, error, color='red')# label='Error')
-		self.axes.plot(wave, flux, color='black')#, label='Flux')
+		self.axes.lines[0] = self.axes.plot(wave, error, color='red')# label='Error')
+		self.axes.lines[1] = self.axes.plot(wave, flux, color='black')#, label='Flux')
 		#self.axes.legend(loc='upper right')
-		self.axes.set_ylim([-np.min(flux)*0.01, np.median(flux)*3])
-		self.axes.set_xlabel('Wavelength')
+		self.axes.set_ylim([-np.nanmin(flux)*0.01, np.nanmedian(flux)*3])
+		self.axes.set_xlabel('Wavelength (Angstrom)')
 		self.axes.set_ylabel('Flux')
 		self.axes.set_title(filename)
 		self.draw()
@@ -93,7 +93,7 @@ class MplCanvas(FigureCanvasQTAgg):
 		ylim = axes.get_ylim()
 		self.axes.lines[0] = axes.plot(wave, new_err, color='red')# label='Error')
 		self.axes.lines[1] = axes.plot(wave, new_spec, color='black')#, label='Flux')
-		#self.axes.legend(loc='upper right')
+		self.axes.set_ylim([np.nanmin(new_spec), np.nanmax(new_spec)])
 		del self.axes.lines[-2:]
 
 	def _compute_distance(self, gxval, gyval, event):
@@ -242,7 +242,7 @@ class MplCanvas(FigureCanvasQTAgg):
 		# 1d spec plot... (keep same varname as axes in plot_spec)
 		self.axes.plot(wave, self.error, color='red')
 		self.axes.plot(wave, self.flux, color='black')
-		self.axes.set_xlabel('Wavelength')
+		self.axes.set_xlabel('Wavelength (Angstrom)')
 		self.axes.set_ylabel('Flux')
 		xlim_spec1d = self.axes.get_xlim()
 		self.axes.set_xlim(xlim_spec1d)
@@ -251,7 +251,7 @@ class MplCanvas(FigureCanvasQTAgg):
 		# scaling first
 		if scale == 0:
 			# Linear.. nothing happened
-			scaled2d = copy.deepcopy(self.flux2d)
+			scaled2d = self.flux2d.copy()
 		elif scale == 1:
 			# log transformation.. scaled = log(1+ img)/log(1+img_max)
 			if self.flux2d.min() < 0:
@@ -270,7 +270,9 @@ class MplCanvas(FigureCanvasQTAgg):
 		# normalization next
 		# send scaling limits back to toolbar
 		if type(normalization) == int:
+			#print(scaled2d)
 			if normalization == 0:
+				
 				self.send_scale_limits.emit([scaled2d.min(), scaled2d.max()])
 			elif normalization == 1:
 				# minmax 100% range
@@ -319,18 +321,21 @@ class MplCanvas(FigureCanvasQTAgg):
 		self.init_xlims = self.axes.get_xlim()
 		self.init_ylims = self.axes.get_ylim()
 
+		#del scaled2d
+
 		# a dummy var to tell if ax2d is available later for event.key='C'
 		self.axnum = 2
 
-	def replot2d(self, wave, new_spec):
+	def replot2d(self, wave, new_spec, new_err):
 		'''Re-plot smoothed/unsmoothed spectrum
 		'''
 		axes = self.figure.gca()
 		xlim = axes.get_xlim()
 		ylim = axes.get_ylim()
-		self.axes.lines[0] = axes.plot(wave, new_spec, color='black')#, label='Flux')
-		#self.axes.legend(loc='upper right')
-		del self.axes.lines[-1:]
+		self.axes.lines[0] = axes.plot(wave, new_err, color='red')# label='Error')
+		self.axes.lines[1] = axes.plot(wave, new_spec, color='black')#, label='Flux')
+		self.axes.set_ylim([np.nanmin(new_spec), np.nanmax(new_spec)])
+		del self.axes.lines[-2:]
 
 #------------------- Keyboards/Mouse Events------------------------
 	def ontype(self, event):

--- a/GUIs/gui_dev/utils.py
+++ b/GUIs/gui_dev/utils.py
@@ -6,7 +6,8 @@ import sys
 
 class FitsObj():
 	def __init__(self, wave, flux, error, 
-				ra=None, dec=None, z_est=None, flag=None):
+				ra=None, dec=None, z_est=None, flag=None,
+				flux2d=None, error2d=None):
 		self.wave = wave
 		self.flux = flux
 		self.error = error
@@ -15,8 +16,6 @@ class FitsObj():
 		self.z_est = z_est
 		self.flag = flag
 
-class FitsObj2d():
-	def __init__(self, wave, flux2d, error2d=None):
-		self.wave = wave
+		# if fits file contains an image
 		self.flux2d = flux2d
 		self.error2d = error2d


### PR DESCRIPTION
IO updates:
1. For fits files that didn't have WAVELENGTH array, looking for headers and creating wave array; for fits files that have WAVELENGTH array, looking for the unit header to convert everything into Angstrom.
2. For a pair of 1D (suffix=x1d.fits) and 2D (suffix=cal.fits) spectra, searching for the complementary fits file. The default canvas view should be the complementary 1D spec instead of extracting 1D from 2D.

Plotting updates:
1. Avoid inserting or deleting operations in the middle of the list from any axes.lines/axes.collections/axes.texts. Get rid of O(n^2) time complexity
2. Always deleting the last element from a collection/list object. Constant O(1) time complexity.
3. Always plotting the primary lines/secondary lines within the display range on the canvas. Switching to a new display range causes the following:
    - deleting every line/text from axes.collections/axes.texts iteratively from the last to the first. (O(1) for 1 deletion, O(n) for all deletions)
    - selecting lines/text within the current display wavelength range (O(1) for all)
    - adding lines/text to axes.collections/axes.texts (O(1) for axes.collections, O(n) for axes.texts)
    - Overall time complexity reduces to O(n) instead of O(n^2)

utils updates:
1. FitsObj custom objects are now generalized to handle 1D/2D at the same time. The only required parameter is the wavelength array. The optional flux2d and error2d are used to store 2D data; the flux and error parameters are preserved for 1D. These varnames are not changed in the plotting canvas.