### PR TITLE
GUI dev bug fixed

### DIFF
--- a/GUIs/gui_dev/gui_io.py
+++ b/GUIs/gui_dev/gui_io.py
@@ -104,6 +104,7 @@ class LoadSpec():
 				file[i].data['<variable>']
 				for multiple i HDU table/image
 				example file: SDSS_spec.fits
+				Note: sdss1.fits is okay; sdss2.fits has header PLUG_RA
 				'''
 				for i in range(len(fitsfile)):
 					search_list = np.array(fitsfile[i].header.cards)


### PR DESCRIPTION
Previous issue - extracted RA/DEC from fitsfile['SCI'].header. [fixed]
New issue - possible headers that contain RA/DEC: PLUG_RA/PLUG_DEC (in sdss2.fits), RA/DEC (in eiger-mock-data), TARG_RA/TARG_DEC (in paired x1d.fits/cal.fits)... Need to figure out a search list to find out RA/DEC

bug fixed:
1. pressing 'r' now resets to the original 1d spec/2d spec.. Always plotting self.flux2d (2D spec), self.flux (1D spec)
2. pressing 'S' and 'U" smooths/unsmooths the 1d spec and returns/plots new_spec. Never changes self.flux
3. pressing 'Y" now precisely selects the extraction boundary with user numerical inputs; pressing 'C' manually selects the extraction boundary.
4. code optimization