### PR TITLE
GUI dev bug fixed

### DIFF
--- a/GUIs/gui_dev/spec_plot.py
+++ b/GUIs/gui_dev/spec_plot.py
@@ -233,7 +233,10 @@ class MplCanvas(FigureCanvasQTAgg):
 		# make sure tmp has no negative values for initial guess
 		tmp_cumsum = np.cumsum(tmp) / np.sum(tmp)
 		ylist = np.arange(0, len(tmp_cumsum), 1)
+		# flux/error are active and extracted from flux2d/error2d
 		self.flux, self.error = self.extract_1d(self.flux2d, self.err2d)
+		# keep a frozen copy and only used for reset
+		self.flux_fix, self.error_fix = self.flux.copy(), self.error.copy()
 
 		#print(tmp_cumsum)
 		lower, upper = 0.16, 0.84
@@ -376,8 +379,10 @@ class MplCanvas(FigureCanvasQTAgg):
 			if self.axnum == 1:
 				self.replot(self.wave, self.flux, self.error)
 			else:
-				self.replot2d(self.wave, self.flux, self.error, self.extraction_y)
-			self.axes.set_ylim([np.nanmin(self.flux), np.nanmax(self.flux)])
+				# reset active flux/error to fixed flux/error
+				self.flux, self.error = self.flux_fix, self.error_fix
+				self.replot2d(self.wave, self.flux_fix, self.error_fix, self.extraction_y)
+			self.axes.set_ylim([np.nanmin(self.flux_fix), np.nanmax(self.flux_fix)])
 			self.axes.set_xlim([np.min(self.wave), np.max(self.wave)])
 			
 			self._lines_in_current_range()
@@ -610,9 +615,9 @@ class MplCanvas(FigureCanvasQTAgg):
 					if len(self.tmp_extraction_y) == 2:
 						(ext_min_y, ext_max_y) = (int(np.round(min(self.tmp_extraction_y))),
 												int(np.round(max(self.tmp_extraction_y))))
-						self.new_spec, self.new_err = self.extract_1d(self.flux2d[ext_min_y:ext_max_y, :], 
+						self.flux, self.error = self.extract_1d(self.flux2d[ext_min_y:ext_max_y, :], 
 																	self.err2d[ext_min_y:ext_max_y, :])
-						self.replot2d(self.wave, self.new_spec, self.new_err, [ext_min_y,ext_max_y])
+						self.replot2d(self.wave, self.flux, self.error, [ext_min_y,ext_max_y])
 						self.tmp_extraction_y = []
 					self.draw()
 				else:

--- a/GUIs/gui_dev/spec_plot.py
+++ b/GUIs/gui_dev/spec_plot.py
@@ -382,7 +382,7 @@ class MplCanvas(FigureCanvasQTAgg):
 				# reset active flux/error to fixed flux/error
 				self.flux, self.error = self.flux_fix, self.error_fix
 				self.replot2d(self.wave, self.flux_fix, self.error_fix, self.extraction_y)
-			self.axes.set_ylim([np.nanmin(self.flux_fix), np.nanmax(self.flux_fix)])
+			self.axes.set_ylim([np.nanmin(self.flux), np.nanmax(self.flux)])
 			self.axes.set_xlim([np.min(self.wave), np.max(self.wave)])
 			
 			self._lines_in_current_range()


### PR DESCRIPTION
Bugs fixed. (hopefully)
Variable namespace:
self.flux2d, self.error2d = 2d spec, 2d error spec from fits files
self.flux, self.error = active 1d spec, 1d error spec extracted from 2d spec 
self.flux_fix, self.error_fix = frozen 1d spec, 1d error initially extracted from 2d spec at the very first time
self.new_spec, self.new_err = smoothed/unsmoothed 1d spec, 1d error spec for display only.

Smooth/Unsmooth apply on self.flux and self.error... self.scale keeps tracks on the convolution kernel size.
Gaussian fitting applies on self.flux and self.error... Fitting only initiated on self.flux and self.error