### PR TITLE
Bug Fixed: Fixed z_guess if queried z_guess > 0

### DIFF
--- a/GUIs/gui_dev/tableview_pandas.py
+++ b/GUIs/gui_dev/tableview_pandas.py
@@ -56,6 +56,9 @@ class CustomZTable(QtWidgets.QWidget):
 			ind = self.estZ[self.estZ['Name'] == sent_data['Name']].index.values[0]
 			s = self.estZ.iloc[ind].to_dict()
 			#print(s)
+			if float(s['z_guess']) > 0:
+				#print(type(sent_data))
+				sent_data.pop('z_guess', None)
 			s.update(sent_data)                                                    
 			self.estZ.iloc[ind] = s
 		else:


### PR DESCRIPTION
Bug Fixed:
1. If GUI finds z_guess > 0 and adds it to the database, z_guess in the database cannot be overridden anymore